### PR TITLE
Update commonmark

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -1,7 +1,6 @@
-import commonmark from 'commonmark'
+const commonmark = require('commonmark')
 
 let reader = new commonmark.DocParser()
 let writer = new commonmark.HtmlRenderer()
 
 export default (markdown) => writer.render(reader.parse(markdown))
-

--- a/es6.js
+++ b/es6.js
@@ -1,6 +1,6 @@
 const commonmark = require('commonmark')
 
-let reader = new commonmark.DocParser()
+let reader = new commonmark.Parser()
 let writer = new commonmark.HtmlRenderer()
 
 export default (markdown) => writer.render(reader.parse(markdown))

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "es5.js",
   "scripts": {
-    "test": "npm start && 6to5-node test --modules commonInterop | tap-spec",
-    "start": "6to5 --modules commonInterop es6.js > es5.js"
+    "test": "npm start && babel-node test --modules commonInterop | tap-spec",
+    "start": "babel es6.js -o es5.js"
   },
   "author": "Brian LeRoux",
   "license": "Apache2",
@@ -13,7 +13,7 @@
     "commonmark": "^0.22.0"
   },
   "devDependencies": {
-    "6to5": "*",
+    "babel": "5.8.23",
     "tap-spec": "^2.2.2",
     "tape": "^4.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Brian LeRoux",
   "license": "Apache2",
   "dependencies": {
-    "commonmark": "^0.12.0"
+    "commonmark": "^0.22.0"
   },
   "devDependencies": {
     "6to5": "*",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "6to5": "*",
-    "tap-spec": "^2.1.0",
-    "tape": "^3.0.3"
+    "tap-spec": "^2.2.2",
+    "tape": "^4.2.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -10,3 +10,13 @@ test('exists', (t) => {
   t.ok(toHTML, 'toHTML lib exists')
   t.end()
 })
+
+test('converts markdown to HTML', (t) => {
+  t.equal(
+    toHTML('Hello *world*'),
+    '<p>Hello <em>world</em></p>\n',
+    'spits out full-blown HTML'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
Hi,

I wanted to update _commonmark_ to the newest version.

When I attempted to run your tests, it turned out that the `6to5: '*'` dependency installed a non-compatible version of _6to5_ (`ReferenceError: es6.js: Unknown module formatter type "commonInterop"`). So I updated all `devDependencies` as well.

I only left _tap-spec_ at version 2. It works well and doesn’t have [a serious bug](https://github.com/scottcorgan/tap-spec/issues/34) which sticks around since v3.

It was me who wrote you an email about this update some time ago, BTW. I managed to track down your project on github after all. 😃
